### PR TITLE
Export GVariable and its methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+0.2.6.1
+-----
+* Exported `Ersatz.Variable.GVariable`
+
 0.2.6
 -----
 * `temporary 1.2` support

--- a/ersatz.cabal
+++ b/ersatz.cabal
@@ -1,5 +1,5 @@
 name:           ersatz
-version:        0.2.6
+version:        0.2.6.1
 license:        BSD3
 license-file:   LICENSE
 author:         Edward A. Kmett, Johan Kiviniemi

--- a/src/Ersatz/Variable.hs
+++ b/src/Ersatz/Variable.hs
@@ -14,6 +14,7 @@
 --------------------------------------------------------------------
 module Ersatz.Variable
   ( Variable(..)
+  , GVariable(..)
   ) where
 
 import Control.Monad


### PR DESCRIPTION
Exporting this class and its methods enables authors
to use the generically derived exists and forall implementations
as utilities while generating their own instances.
