### PR TITLE
performance improvements (CNF printing and parsing)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,10 @@ wip
 .*.swp
 .*.swo
 *.o
+*.p_o
 *.hi
+*.p_hi
 *~
 *#
+*.prof
+*.hp

--- a/ersatz.cabal
+++ b/ersatz.cabal
@@ -178,7 +178,8 @@ library
     process              >= 1.1      && < 1.3,
     temporary            >= 1.1      && < 1.3,
     transformers         >= 0.3      && < 0.5,
-    unordered-containers == 0.2.*
+    unordered-containers == 0.2.*,
+    attoparsec
 
   if impl(ghc >= 7.4 && < 7.6)
     build-depends: ghc-prim

--- a/ersatz.cabal
+++ b/ersatz.cabal
@@ -297,3 +297,10 @@ test-suite hlint
     build-depends:
       base,
       hlint >= 1.7
+
+test-suite speed
+  type: exitcode-stdio-1.0
+  main-is: Speed.hs
+  hs-source-dirs: tests
+  build-depends: base, ersatz
+            

--- a/ersatz.cabal
+++ b/ersatz.cabal
@@ -200,12 +200,16 @@ library
     Ersatz.Solver.DepQBF
     Ersatz.Solver.Minisat
     Ersatz.Variable
+    Ersatz.Counting
+    Ersatz.Relation
 
   other-modules:
     Ersatz.Internal.Parser
     Ersatz.Internal.StableName
     Ersatz.Solver.Common
-
+    Ersatz.Relation.Data
+    Ersatz.Relation.Prop
+    Ersatz.Relation.Op
 
 executable ersatz-regexp-grid
   -- description: An example program that solves the regular expression crossword problem <http://www.coinheist.com/rubik/a_regular_crossword/> using Ersatz.
@@ -304,4 +308,9 @@ test-suite speed
   main-is: Speed.hs
   hs-source-dirs: tests
   build-depends: base, ersatz
-            
+
+test-suite moore
+  type: exitcode-stdio-1.0
+  main-is: Moore.hs
+  hs-source-dirs: tests
+  build-depends: base, array, mtl, ersatz

--- a/ersatz.cabal
+++ b/ersatz.cabal
@@ -314,3 +314,9 @@ test-suite moore
   main-is: Moore.hs
   hs-source-dirs: tests
   build-depends: base, array, mtl, ersatz
+
+test-suite z001
+  type: exitcode-stdio-1.0
+  main-is: Z001.hs
+  hs-source-dirs: tests
+  build-depends: base, mtl, ersatz

--- a/src/Ersatz/Bit.hs
+++ b/src/Ersatz/Bit.hs
@@ -21,6 +21,7 @@ module Ersatz.Bit
   ( Bit(..)
   , assert
   , Boolean(..)
+  , full_Adder_Carry, full_Adder_Sum
   ) where
 
 import Prelude hiding ((&&),(||),not,and,or,all,any)
@@ -56,12 +57,14 @@ infixr 0 ==>
 -- | A 'Bit' provides a reference to a possibly indeterminate boolean
 -- value that can be determined by an external SAT solver.
 data Bit
-  = And (Seq Bit)
-  | Or (Seq Bit) -- ^ not needed because of AIG conversion
-  | Xor Bit Bit
-  | Mux Bit Bit Bit
-  | Not Bit
+  = And !(Seq Bit)
+  | Or !(Seq Bit) -- ^ not needed because of AIG conversion
+  | Xor !Bit !Bit
+  | Mux !Bit !Bit !Bit
+  | Not !Bit
   | Var !Literal
+  | Full_Adder_Sum !Bit !Bit !Bit
+  | Full_Adder_Carry !Bit !Bit !Bit  
   deriving (Show, Typeable)
 
 instance Boolean Bit where
@@ -109,6 +112,13 @@ and2 (And as) b      = And (as |> b)
 and2 a (And bs) = And (a <| bs)
 and2 a b = And (a <| b <| Seq.empty)
 
+full_Adder_Sum (Not a) b c = not (full_Adder_Sum a b c)
+full_Adder_Sum a (Not b) c = not (full_Adder_Sum a b c)
+full_Adder_Sum a b (Not c) = not (full_Adder_Sum a b c)
+full_Adder_Sum a b c = Full_Adder_Sum a b c
+
+full_Adder_Carry a b c = Full_Adder_Carry a b c
+     
 instance Variable Bit where
   literally = liftM Var . literally
 
@@ -171,6 +181,9 @@ runBit b = generateLiteral b $ \out ->
               -- formulaOr  out `liftM` mapM runBit (toList bs)
     Xor x y   -> liftM2 (formulaXor out) (runBit x) (runBit y)
     Mux x y p -> liftM3 (formulaMux out) (runBit x) (runBit y) (runBit p)
+
+    Full_Adder_Sum   a b c -> liftM3 (formulaFAS out) (runBit a) (runBit b) (runBit c)
+    Full_Adder_Carry a b c -> liftM3 (formulaFAC out) (runBit a) (runBit b) (runBit c)
 
     -- Already handled above but GHC doesn't realize it.
     Not _ -> error "Unreachable"

--- a/src/Ersatz/Bit.hs
+++ b/src/Ersatz/Bit.hs
@@ -36,6 +36,7 @@ import Data.Foldable (Foldable, toList)
 import Data.Foldable (toList)
 #endif
 import qualified Data.Foldable as Foldable
+import qualified Data.Traversable as Traversable
 import Data.Sequence (Seq, (<|), (|>), (><))
 import qualified Data.Sequence as Seq
 import Data.Typeable
@@ -161,6 +162,11 @@ instance Codec Bit where
 -- | Assert claims that 'Bit' must be 'true' in any satisfying interpretation
 -- of the current problem.
 assert :: (MonadState s m, HasSAT s) => Bit -> m ()
+assert (And bs) = Foldable.for_ bs assert
+-- the following (when switched on, False => True) produces extra clauses, why?
+assert (Not (And bs)) | False = do
+  ls <- Traversable.for bs runBit
+  assertFormula $ fromClause $ foldMap (fromLiteral . negateLiteral) ls
 assert b = do
   l <- runBit b
   assertFormula (formulaLiteral l)

--- a/src/Ersatz/Bits.hs
+++ b/src/Ersatz/Bits.hs
@@ -196,9 +196,9 @@ instance Num Bit1 where
 
 -- | Compute the sum and carry bit from adding three bits.
 fullAdder :: Bit -> Bit -> Bit -> (Bit, Bit) -- ^ (sum, carry)
-fullAdder a b cin = (s2, c1 || c2)
-  where (s1,c1) = halfAdder a b
-        (s2,c2) = halfAdder s1 cin
+fullAdder a b c =
+  ( full_Adder_Sum a b c , full_Adder_Carry a b c )
+  -- let (s1,c1) = halfAdder a b ; (s2,c2) = halfAdder s1 c in (s2, c1||c2)
 
 -- | Compute the sum and carry bit from adding two bits.
 halfAdder :: Bit -> Bit -> (Bit, Bit) -- ^ (sum, carry)

--- a/src/Ersatz/Bits.hs
+++ b/src/Ersatz/Bits.hs
@@ -199,6 +199,7 @@ fullAdder :: Bit -> Bit -> Bit -> (Bit, Bit) -- ^ (sum, carry)
 fullAdder a b c =
   -- ( full_Adder_Sum a b c , full_Adder_Carry a b c )
   let (s1,c1) = halfAdder a b ; (s2,c2) = halfAdder s1 c in (s2, c1||c2)
+  -- following does not work (formula generation does not stop), why?
   {-
   ( Run $ exists >>= \ x -> do
       assert (     a ||     b ||     c || not x ) ; assert ( not a || not b || not c || x )

--- a/src/Ersatz/Bits.hs
+++ b/src/Ersatz/Bits.hs
@@ -197,8 +197,22 @@ instance Num Bit1 where
 -- | Compute the sum and carry bit from adding three bits.
 fullAdder :: Bit -> Bit -> Bit -> (Bit, Bit) -- ^ (sum, carry)
 fullAdder a b c =
-  ( full_Adder_Sum a b c , full_Adder_Carry a b c )
-  -- let (s1,c1) = halfAdder a b ; (s2,c2) = halfAdder s1 c in (s2, c1||c2)
+  -- ( full_Adder_Sum a b c , full_Adder_Carry a b c )
+  let (s1,c1) = halfAdder a b ; (s2,c2) = halfAdder s1 c in (s2, c1||c2)
+  {-
+  ( Run $ exists >>= \ x -> do
+      assert (     a ||     b ||     c || not x ) ; assert ( not a || not b || not c || x )
+      assert (     a || not b || not c || not x ) ; assert ( not a ||     b ||     c || x )
+      assert ( not a ||     b || not c || not x ) ; assert (     a || not b ||     c || x )
+      assert ( not a || not b ||     c || not x ) ; assert (     a ||     b || not c || x )
+      return x
+  , Run $ exists >>= \ x -> do
+      assert ( not b || not c || x ) ; assert ( b || c || not x )
+      assert ( not a || not c || x ) ; assert ( a || c || not x )
+      assert ( not a || not b || x ) ; assert ( a || b || not x )
+      return x
+  )
+  -}
 
 -- | Compute the sum and carry bit from adding two bits.
 halfAdder :: Bit -> Bit -> (Bit, Bit) -- ^ (sum, carry)

--- a/src/Ersatz/Counting.hs
+++ b/src/Ersatz/Counting.hs
@@ -1,0 +1,17 @@
+module Ersatz.Counting where
+
+import Ersatz.Bit
+import Ersatz.Bits
+import Ersatz.Codec
+import Ersatz.Equatable
+import Ersatz.Orderable
+
+exactly :: Int -> [ Bit ] -> Bit
+exactly k bs = encode (fromIntegral k) === sumBit bs
+
+atmost :: Int -> [ Bit ] -> Bit
+atmost k bs = encode (fromIntegral k) >=? sumBits bs
+
+atleast :: Int -> [ Bit ] -> Bit
+atleast k bs = encode (fromIntegral k) <=? sumBits bs
+

--- a/src/Ersatz/Internal/Formula.hs
+++ b/src/Ersatz/Internal/Formula.hs
@@ -25,6 +25,7 @@ module Ersatz.Internal.Formula
   , Formula(..)
   , formulaEmpty, formulaLiteral
   , formulaNot, formulaAnd, formulaOr, formulaXor, formulaMux
+  , formulaFAS, formulaFAC
   ) where
 
 #if __GLASGOW_HASKELL__ < 710
@@ -251,6 +252,25 @@ formulaMux (Literal x) (Literal f) (Literal t) (Literal s) =
     cls = [ [-s, -t,  x], [ s, -f,  x], {- red -} [-t, -f,  x] 
           , [-s,  t, -x], [ s,  f, -x], {- red -} [ t,  t, -x]
           ]
+
+formulaFAS (Literal x) (Literal a) (Literal b) (Literal c) = 
+  formulaFromList cls
+  where
+    cls = 
+      [ [ a,  b,  c, -x], [-a, -b, -c, x]
+      , [ a, -b, -c, -x], [-a,  b,  c, x]
+      , [-a,  b, -c, -x], [ a, -b,  c, x]
+      , [-a, -b,  c, -x], [ a,  b, -c, x]
+      ]
+
+formulaFAC (Literal x) (Literal a) (Literal b) (Literal c) = 
+  formulaFromList cls
+  where
+    cls = 
+      [ [ -b, -c, x], [b, c, -x]
+      , [ -a, -c, x], [a, c, -x]
+      , [ -a, -b, x], [a, b, -x]
+      ]
 
 formulaFromList :: [[Int]] -> Formula
 {-# inline formulaFromList #-}

--- a/src/Ersatz/Internal/Formula.hs
+++ b/src/Ersatz/Internal/Formula.hs
@@ -20,10 +20,10 @@
 module Ersatz.Internal.Formula
   (
   -- * Clauses
-    Clause(..), clauseLiterals
+    Clause(..), clauseLiterals, fromLiteral
   -- * Formulas
   , Formula(..)
-  , formulaEmpty, formulaLiteral
+  , formulaEmpty, formulaLiteral, fromClause
   , formulaNot, formulaAnd, formulaOr, formulaXor, formulaMux
   , formulaFAS, formulaFAC
   ) where
@@ -62,6 +62,9 @@ clauseLiterals (Clause is) = Literal <$> IntSet.toList is
 instance Monoid Clause where
   mempty = Clause mempty
   mappend (Clause x) (Clause y) = Clause (mappend x y)
+
+fromLiteral :: Literal -> Clause
+fromLiteral l = Clause { clauseSet = IntSet.singleton $ literalId l }
 
 ------------------------------------------------------------------------------
 -- Formulas

--- a/src/Ersatz/Problem.hs
+++ b/src/Ersatz/Problem.hs
@@ -74,6 +74,8 @@ import Ersatz.Internal.Formula
 import Ersatz.Internal.Literal
 import Ersatz.Internal.StableName
 import System.IO.Unsafe
+import Data.Sequence (Seq)
+import qualified Data.Sequence as Seq
 
 ------------------------------------------------------------------------------
 -- SAT Problems
@@ -205,7 +207,7 @@ literalForall = do
 class DIMACS t where
   dimacsComments :: t -> [ByteString]
   dimacsNumVariables :: t -> Int
-  dimacsClauses :: t -> Set IntSet
+  dimacsClauses :: t -> Seq IntSet
 
 -- | QDIMACS file format pretty printer
 --
@@ -216,7 +218,7 @@ class QDIMACS t where
   qdimacsComments :: t -> [ByteString]
   qdimacsNumVariables :: t -> Int
   qdimacsQuantified :: t -> [Quant]
-  qdimacsClauses :: t -> Set IntSet
+  qdimacsClauses :: t -> Seq IntSet
 
 -- | WDIMACS file format pretty printer
 --
@@ -227,7 +229,7 @@ class WDIMACS t where
   wdimacsComments :: t -> [ByteString]
   wdimacsNumVariables :: t -> Int
   wdimacsTopWeight :: t -> Int64  -- ^ Specified to be 1 ≤ n < 2^63
-  wdimacsClauses :: t -> Set (Int64, IntSet)
+  wdimacsClauses :: t -> Seq (Int64, IntSet)
 
 -- | Generate a 'Builder' out of a 'DIMACS' problem.
 dimacs :: DIMACS t => t -> Builder
@@ -236,7 +238,7 @@ dimacs t = comments <> problem <> clauses
     comments = foldMap bComment (dimacsComments t)
     problem = bLine [ string7 "p cnf"
                     , intDec (dimacsNumVariables t)
-                    , intDec (Set.size tClauses)
+                    , intDec (Seq.length tClauses)
                     ]
     clauses = foldMap bClause tClauses
 
@@ -249,7 +251,7 @@ qdimacs t = comments <> problem <> quantified <> clauses
     comments = foldMap bComment (qdimacsComments t)
     problem = bLine [ string7 "p cnf"
                     , intDec (qdimacsNumVariables t)
-                    , intDec (Set.size tClauses)
+                    , intDec (Seq.length tClauses)
                     ]
     quantified = foldMap go tQuantGroups
       where go ls = bLine0 (q (head ls) : map (intDec . getQuant) ls)
@@ -272,7 +274,7 @@ wdimacs t = comments <> problem <> clauses
     comments = foldMap bComment (wdimacsComments t)
     problem = bLine [ string7 "p wcnf"
                     , intDec (wdimacsNumVariables t)
-                    , intDec (Set.size tClauses)
+                    , intDec (Seq.length tClauses)
                     , int64Dec (wdimacsTopWeight t)
                     ]
     clauses = foldMap (uncurry bWClause) tClauses
@@ -332,5 +334,8 @@ instance QDIMACS QSAT where
         | otherwise = Exists i : quants is jjs
   qdimacsClauses = satClauses
 
-satClauses :: HasSAT s => s -> Set IntSet
-satClauses s = Set.map clauseSet (formulaSet (s^.formula))
+-- | the name is wrong (Does it return Clauses? No - it returns IntSets.)
+-- and it means extra work (traversing, and re-building, the full collection).
+-- Or is this fused away (because of Coercible)?
+satClauses :: HasSAT s => s -> Seq IntSet
+satClauses s = fmap clauseSet (formulaSet (s^.formula))

--- a/src/Ersatz/Problem.hs
+++ b/src/Ersatz/Problem.hs
@@ -283,7 +283,7 @@ bComment :: ByteString -> Builder
 bComment bs = bLine [ char7 'c', byteString bs ]
 
 bClause :: IntSet -> Builder
-bClause ls = bLine0 (map intDec (IntSet.toList ls))
+bClause = IntSet.foldl' ( \ e i -> intDec i <> char7 ' ' <> e ) ( char7 '0' <> char7 '\n' ) 
 
 bWClause :: Int64 -> IntSet -> Builder
 bWClause w ls = bLine0 (int64Dec w : map intDec (IntSet.toList ls))

--- a/src/Ersatz/Relation.hs
+++ b/src/Ersatz/Relation.hs
@@ -1,0 +1,10 @@
+module Ersatz.Relation
+( module Ersatz.Relation.Data
+, module Ersatz.Relation.Op
+, module Ersatz.Relation.Prop
+) where
+
+import Ersatz.Relation.Data
+import Ersatz.Relation.Op
+import Ersatz.Relation.Prop
+

--- a/src/Ersatz/Relation/Data.hs
+++ b/src/Ersatz/Relation/Data.hs
@@ -1,0 +1,85 @@
+{-# language TypeFamilies #-}
+
+module Ersatz.Relation.Data ( Relation
+, relation, symmetric_relation
+, build
+, identity                      
+, bounds, (!), indices, assocs, elems
+, table
+)  where
+
+import Ersatz.Bit
+import Ersatz.Codec
+import Ersatz.Variable (exists)
+import Ersatz.Problem (HasSAT)
+
+import qualified Data.Array as A
+import Data.Array ( Array, Ix )
+import Control.Monad ( guard, forM )
+import Control.Monad.State
+
+newtype Relation a b = Relation (A.Array (a, b) Bit)
+
+instance (Ix a, Ix b) => Codec (Relation a b) where
+  type Decoded (Relation a b) = A.Array (a, b) Bool
+  decode s (Relation a) = decode s a
+  encode a = Relation $ encode a
+
+relation :: ( Ix a, Ix b, MonadState s m, HasSAT s ) 
+         => ((a,b),(a,b)) -> m ( Relation a b )
+relation bnd = do
+    pairs <- sequence $ do 
+        p <- A.range bnd
+        return $ do
+            x <- exists
+            return ( p, x )
+    return $ build bnd pairs
+    
+symmetric_relation bnd = do
+    pairs <- sequence $ do
+        (p,q) <- A.range bnd
+        guard $ p <= q
+        return $ do
+            x <- exists
+            return $ [ ((p,q), x ) ]
+                   ++ [ ((q,p), x) | p /= q ]
+    return $ build bnd $ concat pairs          
+
+identity :: ( Ix a )
+         => ((a,a),(a,a)) ->  Relation a a 
+identity bnd = build bnd $ for ( A.range bnd) $ \ (i,j) ->
+        ((i,j), if i == j then true else false )
+
+for = flip map
+
+build :: ( Ix a, Ix b ) 
+      => ((a,b),(a,b)) 
+      -> [ ((a,b), Bit ) ]
+      -> Relation a b 
+build bnd pairs = Relation $ A.array bnd pairs
+
+
+bounds :: (Ix a, Ix b) => Relation a b -> ((a,b),(a,b))
+bounds ( Relation r ) = A.bounds r
+
+indices ( Relation r ) = A.indices r
+
+assocs ( Relation r ) = A.assocs r
+
+elems ( Relation r ) = A.elems r
+
+Relation r ! p = r A.! p
+
+
+table :: (Enum a, Ix a, Enum b, Ix b) 
+      => Array (a,b) Bool -> String
+table r = unlines $ do
+    let ((a,b),(c,d)) = A.bounds r
+    x <- [ a .. c ]
+    return $ unwords $ do
+        y <- [ b .. d ]
+        return $ if r A.! (x,y) then "*" else "."
+
+
+
+

--- a/src/Ersatz/Relation/Op.hs
+++ b/src/Ersatz/Relation/Op.hs
@@ -1,0 +1,70 @@
+{-# language FlexibleInstances, MultiParamTypeClasses #-}
+
+module Ersatz.Relation.Op
+
+( mirror
+, union
+, complement
+, product, power
+, intersection
+) 
+
+where
+
+import Ersatz.Relation.Data
+  
+import Prelude hiding ( and, or, not, product )
+import Ersatz.Bit (and, or, not)
+import qualified Prelude
+
+import Control.Monad ( guard )
+import Data.Ix
+
+mirror :: ( Ix a , Ix b ) => Relation a b -> Relation b a
+mirror r = 
+    let ((a,b),(c,d)) = bounds r
+    in  build ((b,a),(d,c)) $ do (x,y) <- indices r ; return ((y,x), r!(x,y))
+
+complement :: ( Ix a , Ix b ) => Relation a b -> Relation a b
+complement r = 
+    build (bounds r) $ do i <- indices r ; return ( i, not $ r!i )
+
+
+union :: ( Ix a , Ix b )
+        => Relation a b -> Relation a b ->  Relation a b
+union r s =  build ( bounds r ) $ do
+    i <- indices r
+    return (i, or [ r!i, s!i ] )
+
+product :: ( Ix a , Ix b, Ix c )
+        => Relation a b -> Relation b c ->  Relation a c 
+product a b = 
+    let ((ao,al),(au,ar)) = bounds a
+        ((bo,bl),(bu,br)) = bounds b
+        bnd = ((ao,bl),(au,br))
+    in  build bnd $ do
+          i @ (x,z) <- range bnd
+          return (i, or $ do
+                y <- range ( al, ar )
+                return $ and [ a!(x,y), b!(y,z) ]
+                ) 
+            
+power  :: ( Ix a  ) 
+        => Int -> Relation a a -> Relation a a 
+power 0 r = identity ( bounds r ) 
+power 1 r = r
+power e r = 
+    let (d,m) = divMod e 2
+        s = power d r
+        s2 = product s s
+    in  case m of
+        0 -> s2
+        1 -> product s2 r
+
+intersection :: ( Ix a , Ix b)
+      => Relation a b -> Relation a b 
+      -> Relation a b 
+intersection r s = build ( bounds r ) $ do
+        i <- indices r
+        return (i, and [ r!i, s!i ] )
+

--- a/src/Ersatz/Relation/Prop.hs
+++ b/src/Ersatz/Relation/Prop.hs
@@ -1,0 +1,90 @@
+
+module Ersatz.Relation.Prop
+
+( implies
+, symmetric 
+, transitive
+, irreflexive
+, reflexive
+, regular
+, regular_in_degree
+, regular_out_degree
+, max_in_degree
+, min_in_degree
+, max_out_degree
+, min_out_degree
+, empty
+, complete
+, disjoint
+, equals
+)
+
+where
+
+import Prelude hiding ( and, or, not, product )
+import Ersatz.Bit
+import Ersatz.Relation.Data
+import Ersatz.Relation.Op
+import Ersatz.Counting
+
+import qualified Prelude
+
+import Control.Monad ( guard )
+import Data.Ix
+
+implies :: ( Ix a, Ix b )
+        => Relation a b -> Relation a b -> Bit
+implies r s = and $ do
+    i <- indices r
+    return $ or [ not $ r ! i, s ! i ]
+
+empty ::  ( Ix a, Ix b ) 
+        => Relation a b -> Bit
+empty r = and $ do
+    i <- indices r
+    return $ not $ r ! i
+
+complete r = empty $ complement r
+
+disjoint r s = empty $ intersection r s
+    
+equals r s = and [implies r s, implies s r]
+
+symmetric :: ( Ix a) => Relation a a -> Bit
+symmetric r = implies r ( mirror r )
+
+irreflexive :: ( Ix a ) => Relation a a -> Bit
+irreflexive r = and $ do
+    let ((a,b),(c,d)) = bounds r
+    x <- range ( a, c)
+    return $ not $ r ! (x,x) 
+
+reflexive :: ( Ix a ) => Relation a a -> Bit
+reflexive r = and $ do
+    let ((a,b),(c,d)) = bounds r
+    x <- range (a,c)
+    return $ r ! (x,x) 
+
+regular, regular_in_degree, regular_out_degree, max_in_degree, min_in_degree, max_out_degree, min_out_degree :: ( Ix a ) => Int -> Relation a a -> Bit
+
+regular deg r = and [ regular_in_degree deg r, regular_out_degree deg r ]
+
+regular_out_degree = out_degree_helper exactly
+max_out_degree = out_degree_helper atmost
+min_out_degree = out_degree_helper atleast
+regular_in_degree deg r = regular_out_degree deg $ mirror r
+max_in_degree deg r = max_out_degree deg $ mirror r
+min_in_degree deg r = min_out_degree deg $ mirror r
+
+
+out_degree_helper f deg r = and $ do
+    let ((a,b),(c,d)) = bounds r
+    x <- range ( a , c )
+    return $ f deg $ do 
+        y <- range (b,d)
+        return $ r !(x,y)
+
+transitive :: ( Ix a ) 
+           => Relation a a -> Bit
+transitive r = implies (product r r) r
+

--- a/src/Ersatz/Solution.hs
+++ b/src/Ersatz/Solution.hs
@@ -23,7 +23,7 @@ import Control.Applicative
 import Control.Lens
 import qualified Data.HashMap.Lazy as HashMap
 import Data.IntMap (IntMap)
-import qualified Data.IntMap as IntMap
+import qualified Data.IntMap.Strict as IntMap
 import Data.Ix
 import Data.Typeable
 import Ersatz.Internal.Literal

--- a/src/Ersatz/Solver/Minisat.hs
+++ b/src/Ersatz/Solver/Minisat.hs
@@ -26,7 +26,7 @@ import Ersatz.Internal.Parser
 import Ersatz.Problem
 import Ersatz.Solution
 import Ersatz.Solver.Common
-import qualified Data.IntMap as IntMap
+import qualified Data.IntMap.Strict as IntMap
 import System.IO
 import System.Process (readProcessWithExitCode)
 

--- a/src/Ersatz/Solver/Minisat.hs
+++ b/src/Ersatz/Solver/Minisat.hs
@@ -50,7 +50,9 @@ cryptominisat = minisatPath "cryptominisat"
 minisatPath :: MonadIO m => FilePath -> Solver SAT m
 minisatPath path problem = liftIO $
   withTempFiles ".cnf" "" $ \problemPath solutionPath -> do
-    timed ( "write dimacs" ++ " (" ++ show (dimacsNumVariables problem) ++ " vars)" ) $ withFile problemPath WriteMode $ \fh ->
+    timed ( "write dimacs" ++ " (" ++ show (dimacsNumVariables problem) ++ " variables, "
+                                   ++ show (length $ dimacsClauses problem) ++ " clauses" ++ ")" )
+         $ withFile problemPath WriteMode $ \fh ->
       hPutBuilder fh (dimacs problem)
 
     (exit, _out, _err) <- timed "run minisat" $ 

--- a/src/Ersatz/Solver/Minisat.hs
+++ b/src/Ersatz/Solver/Minisat.hs
@@ -50,10 +50,10 @@ cryptominisat = minisatPath "cryptominisat"
 minisatPath :: MonadIO m => FilePath -> Solver SAT m
 minisatPath path problem = liftIO $
   withTempFiles ".cnf" "" $ \problemPath solutionPath -> do
-    timed "write dimacs" $ withFile problemPath WriteMode $ \fh ->
+    timed ( "write dimacs" ++ " (" ++ show (dimacsNumVariables problem) ++ " vars)" ) $ withFile problemPath WriteMode $ \fh ->
       hPutBuilder fh (dimacs problem)
 
-    (exit, _out, _err) <- timed ("run minisat" ++ " (on " ++ show (dimacsNumVariables problem) ++ " vars)" ) $ 
+    (exit, _out, _err) <- timed "run minisat" $ 
       readProcessWithExitCode path [problemPath, solutionPath] []
     
     sol <- timed "parse output" $ parseSolutionFile solutionPath

--- a/tests/Moore.hs
+++ b/tests/Moore.hs
@@ -1,0 +1,78 @@
+-- | graphs n nodes of degree <= d and diameter <= k 
+-- see http://combinatoricswiki.org/wiki/The_Degree_Diameter_Problem_for_General_Graphs
+
+-- usage: ./Moore d k n [s]
+-- d : degree
+-- k : diameter
+-- n : nodes,
+-- s : modulus for symmetry (see periodic_relation below)
+-- s smaller => faster (more symmetries) but may lose solutions
+
+-- test cases:  3 2 10 2  -- petersen graph
+--              5 2 24    
+
+
+{-# language FlexibleContexts #-}
+
+import Prelude hiding ( not, or, and )
+import qualified Prelude
+
+import Ersatz
+import Ersatz.Bit
+import qualified Ersatz.Relation as R
+
+import qualified Data.Array as A
+import System.Environment (getArgs)
+import Control.Monad ( void, when, forM )
+import Control.Monad.State
+
+main :: IO ( )
+main = do
+  argv <- getArgs
+  case argv of
+    [ d, k, n, s ] ->
+      void $ mainf ( read d ) (read k) (read n) (read s)
+    [ d, k, n    ] ->
+      void $ mainf ( read d ) (read k) (read n) (read n)
+    [] -> void $ mainf 3 2 10 5 -- petersen
+
+mainf d k n s = do
+  putStrLn $ unwords [ "degree <=", show d, "diameter <=", show k, "nodes ==", show n, "symmetry ==", show s ]
+  (s, mg) <- solveWith minisat $ moore d k n s
+  case (s, mg) of
+     (Satisfied, Just g) -> do printA g ; return True
+     _ -> do return False
+
+moore :: (MonadState s m, HasSAT s )
+      => Int -> Int -> Int -> Int
+      -> m (R.Relation Int Int)
+moore d k n s = do
+  -- g <- R.symmetric_relation ((0,0),(n-1,n-1))
+  g <- periodic_relation s ((0,0),(n-1,n-1))
+  assert $ R.symmetric g
+  assert $ R.reflexive g 
+  assert $ R.max_in_degree (d+1) g 
+  assert $ R.max_out_degree (d+1) g 
+  let p = R.power k g
+  assert $ R.complete p 
+  return g
+
+periodic_relation s bnd = do
+  r <- R.relation bnd
+  let normal (x,y) =
+        if (x >= s Prelude.&& y >= s)
+        then normal (x-s,y-s)  else (x,y)
+  return $ R.build bnd $ do
+    i <- A.range bnd
+    return (i, r R.! normal i)
+  
+-- | FIXME: this needs to go into a library
+printA :: A.Array (Int,Int) Bool -> IO ()
+printA a = putStrLn $ unlines $ do
+         let ((u,l),(o,r)) = A.bounds a
+         x <- [u .. o]
+         return $ unwords $ do 
+             y <- [ l ..r ]
+             return $ case a A.! (x,y) of
+                  True -> "* " ; False -> ". "
+

--- a/tests/Speed.hs
+++ b/tests/Speed.hs
@@ -1,0 +1,23 @@
+import Ersatz
+import Ersatz.Bit
+import Ersatz.Variable (exists)
+
+import System.Environment (getArgs)
+import Control.Monad ( forM_, replicateM )
+
+main :: IO ( )
+main = do
+  argv <- getArgs
+  case argv of
+    [ n ] -> mainf ( read n)
+    [] -> mainf 50000
+
+mainf n = do
+  putStrLn $ unwords [ "n",  show n ]
+  (s, mgs) <- solveWith minisat $ do
+      gs <- replicateM n exists
+      forM_ (zip gs $ tail gs) $ \ (x,y) -> assert ( x /== y )
+      return (gs :: [Bit])
+  case (s, mgs) of
+     (Satisfied, Just gs) -> do print $ length $ filter id gs
+     _ -> do return ()

--- a/tests/Z001.hs
+++ b/tests/Z001.hs
@@ -1,0 +1,118 @@
+{-# language KindSignatures, DataKinds, FlexibleContexts #-}
+{-# language GeneralizedNewtypeDeriving #-}
+{-# language TypeFamilies, ScopedTypeVariables #-}
+
+{-# language NoMonomorphismRestriction #-}
+
+import Prelude hiding ( not, and, or, (&&), (||) )
+
+import Ersatz
+
+import GHC.TypeLits
+import Data.Proxy
+import Data.List ( transpose )
+import Control.Monad ( replicateM, forM_ )
+import Control.Monad.State
+
+main = do
+  (Satisfied, Just ms) <- solveWith minisat $ do
+    [ Restricted a, Restricted b ]
+        :: [ Restricted 5 (NBV 3) ] <- replicateM 2 unknown
+    -- assert $ gt (a^2 * b^2) (b^3 * a^3)
+    let a2 = a^2 ; b2 = b^2
+    assert $ gt (a2 * b2) (b2 * b * a * a2)
+    return [a,b]
+  forM_ ms print
+
+unknown_monotone = do
+   m <- unknown ; assert $ monotone m ; return m
+
+newtype Restricted d a = Restricted (Matrix d a)
+
+instance (KnownNat dim, Unknown a, Codec a, Num (Decoded a))
+  => Unknown (Restricted dim a) where
+  unknown = do
+    let d = fromIntegral $ natVal (Proxy :: Proxy dim)
+        row f = ( encode f : ) <$> replicateM (d-1) unknown
+    m <- (:) <$> row 1 <*> replicateM (d-2) (row 0)
+    return $ Restricted $ Matrix
+       $ m ++ encode [ replicate (d-1) 0 ++ [1] ] 
+
+class Unknown a where
+  unknown :: (MonadState s m, HasSAT s) => m a
+
+-- | square matrices
+newtype Matrix (dim::Nat)  a = Matrix [[a]]
+  deriving ( Show, Equatable, Orderable )
+
+instance Codec a => Codec (Matrix dim a) where
+  type Decoded (Matrix dim a) = Matrix dim (Decoded a)
+  decode s (Matrix xss) = Matrix <$> decode s xss
+    
+instance (KnownNat dim, Unknown a) => Unknown (Matrix dim a) where
+  unknown = do
+    let d = fromIntegral $ natVal (Proxy :: Proxy dim)
+    Matrix <$> replicateM d (replicateM d unknown)
+    
+instance Num a => Num (Matrix dim a) where
+  Matrix xss + Matrix yss
+    = Matrix $ zipWith (zipWith (+)) xss yss
+  Matrix xss * Matrix yss
+    = Matrix $ for xss $ \ row ->
+        for (transpose yss) $ \ col ->
+          sum $ zipWith (*) row col
+
+for = flip map
+
+topleft (Matrix xss) = head (head xss)
+botright (Matrix xss) = last (last xss)
+topright (Matrix xss) = last (head xss)
+
+monotone m = positive (topleft m) && positive (botright m)
+
+ge :: Orderable a => Matrix dim a -> Matrix dim a -> Bit
+ge (Matrix xss) (Matrix yss) =
+  and $ zipWith (>=?) (concat xss) (concat yss)
+
+gt :: Orderable a => Matrix dim a -> Matrix dim a -> Bit
+gt a b = ge a b && topright a >? topright b
+
+-- | NBV = Non-overflowing Bitvector
+-- Bitvectors of fixed length, with non-overflowing arithmetics
+-- (if overflow occurs, constraint is unsatisfiable)
+
+newtype NBV ( n :: Nat ) = NBV Bits 
+  deriving ( Show, Equatable, Orderable, HasBits )
+
+instance KnownNat w => Unknown (NBV w) where
+  unknown = do
+    let n = fromIntegral $ natVal (Proxy :: Proxy w)
+    NBV <$> Bits <$> replicateM n exists
+
+positive (NBV (Bits bs)) = or bs
+
+nbv n (Bits bs) = 
+  let (p : re, post) = splitAt n bs
+  in  NBV $ Bits $ Run ( assert (not $ or post) *> return p )
+                 : re 
+
+instance KnownNat n => Num (NBV n) where
+  fromInteger = encode
+  NBV a + NBV b =
+    nbv (fromIntegral (natVal (Proxy :: Proxy n))) $ a + b
+  NBV a * NBV b =
+    nbv (fromIntegral (natVal (Proxy :: Proxy n))) $ a * b
+
+instance KnownNat n => Codec (NBV n) where
+  type Decoded (NBV n) = Integer
+  decode s (NBV bs) = decode s bs
+  encode i =
+    let n = fromIntegral $ natVal (Proxy :: Proxy n)
+        Bits bs = encode i
+        (pre, post) = splitAt n bs
+    in  if null post
+        then NBV (Bits $ take n $ pre ++ repeat false)
+        else error $ unwords
+             [ "cannot encode", show i
+             , "with given bit width", show n
+             ]


### PR DESCRIPTION
Hi, I have noticed performance problems (issues #16 and #17) and made some improvements (example: from 40 seconds to 7 seconds)

Writing the CNF still feels sluggish - for large trivial formulas, minisat can (read and) solve much faster than Ersatz writes.