### PR TITLE
Fix tests when building with stack

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,9 @@ sudo: false
 matrix:
   include:
     - env: CABALVER=1.22 GHCVER=7.10.3 GHCOPTS="" JOPTS="-j2"
-      addons: {apt: {packages: [cabal-install-1.22, ghc-7.10.3],sources: [hvr-ghc]}}
+      addons: {apt: {packages: [cabal-install-1.22, ghc-7.10.3, minisat],sources: [hvr-ghc]}}
     - env: CABALVER=1.24 GHCVER=8.0.1 GHCOPTS="" JOPTS="-j2"
-      addons: {apt: {packages: [cabal-install-1.24,ghc-8.0.1],  sources: [hvr-ghc]}}
+      addons: {apt: {packages: [cabal-install-1.24,ghc-8.0.1, minisat],  sources: [hvr-ghc]}}
 
   allow_failures:
    - env: CABALVER=head GHCVER=head GHCOPTS="" JOPTS="-j2"

--- a/Setup.lhs
+++ b/Setup.lhs
@@ -41,6 +41,10 @@ generateBuildModule verbosity pkg lbi = do
     withTestLBI pkg lbi $ \suite suitecfg -> do
       rewriteFile (dir </> "Build_" ++ testName suite ++ ".hs") $ unlines
         [ "module Build_" ++ testName suite ++ " where"
+        , ""
+        , "autogen_dir :: String"
+        , "autogen_dir = " ++ show dir
+        , ""
         , "deps :: [String]"
         , "deps = " ++ (show $ formatdeps (testDeps libcfg suitecfg))
         ]

--- a/tests/doctests.hsc
+++ b/tests/doctests.hsc
@@ -15,7 +15,7 @@
 -----------------------------------------------------------------------------
 module Main where
 
-import Build_doctests (deps)
+import Build_doctests (autogen_dir, deps)
 #if __GLASGOW_HASKELL__ < 710
 import Control.Applicative
 #endif
@@ -56,11 +56,10 @@ withUnicode m = m
 main :: IO ()
 main = withUnicode $ getSources >>= \sources -> doctest $
     "-isrc"
-  : "-idist/build/autogen"
+  : ("-i" ++ autogen_dir)
   : "-optP-include"
-  : "-optPdist/build/autogen/cabal_macros.h"
+  : ("-optP" ++ autogen_dir ++ "/cabal_macros.h")
   : "-hide-all-packages"
-  : "-Iincludes"
   : map ("-package="++) deps ++ sources
 
 getSources :: IO [FilePath]


### PR DESCRIPTION
Currently, the doctests fail since it can't find the directory that `stack` puts autogen'd files in.

This would allow `ersatz`'s tests to be [put on Stackage](https://github.com/fpco/stackage/blob/bf81e7c57f709cb5eccde88c0bcfc76a4474a865/build-constraints.yaml#L2795).