### PR TITLE
define and export  assertClause

### DIFF
--- a/src/Ersatz/Bit.hs
+++ b/src/Ersatz/Bit.hs
@@ -22,6 +22,7 @@
 module Ersatz.Bit
   ( Bit(..)
   , assert
+  , assertClause
   , Boolean(..)
   ) where
 
@@ -170,6 +171,13 @@ assert (Not (And bs)) | False = do
 assert b = do
   l <- runBit b
   assertFormula (formulaLiteral l)
+
+-- | @assertClause xs@ is @assert $ or xs@ but does create
+-- exactly one clause (and no auxiliary literal)
+assertClause :: (MonadState s m, HasSAT s, Foldable f) => f Bit -> m ()
+assertClause bs = do
+  ls <- forM (toList bs) runBit
+  assertFormula $ fromClause $ foldMap fromLiteral ls
 
 -- | Convert a 'Bit' to a 'Literal'.
 runBit :: (MonadState s m, HasSAT s) => Bit -> m Literal


### PR DESCRIPTION
Hi, I often need this function `assertClause :: [Bit] -> m()`. Semantically, it is `assert . or` 
but this would create extra clauses (sometimes, a lot of them).