### PR TITLE
Avoid a failable pattern match in Ersatz.BitChar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+next [????.??.??]
+-----------------
+* Avoid the use of failable pattern matches in `do`-notation to support
+  building with GHC 8.6, which enables `MonadFailDesugaring`.
+
 0.4.3 [2018.07.03]
 ------------------
 * Make the test suite compile on GHC 8.6.

--- a/src/Ersatz/BitChar.hs
+++ b/src/Ersatz/BitChar.hs
@@ -48,7 +48,8 @@ instance Variable BitChar where
        -- Char upperbound is 0x10ffff, so only set
        -- the high bit when the next 4 bits are 0
 
-    do x:xs <- replicateM 21 (literally m)
+    do x  <- literally m
+       xs <- replicateM 20 (literally m)
 
        let x' = x && nor (take 4 xs)
            n  = Bits (reverse (x':xs)) -- Bits is little endian


### PR DESCRIPTION
`ersatz` fails to build on GHC 8.6 because it enables `MonadFailDesugaring` by default, and there is no `MonadFail` constraint to support a failable pattern match on a list in `Ersatz.BitChar`. But this pattern match is a bit silly anyways, since we know statically that this list is always non-empty, so we can avoid this pattern match entirely.

Addresses one bullet point of ekmett/lens#815.