### PR TITLE
Add Equatable instances for base types

### DIFF
--- a/src/Ersatz/Equatable.hs
+++ b/src/Ersatz/Equatable.hs
@@ -24,7 +24,7 @@ import Prelude hiding ((&&),(||),not,and,or,all,any)
 
 import Ersatz.Bit
 import GHC.Generics
-import GHC.Natural
+import Numeric.Natural
 import Data.IntMap (IntMap)
 import Data.Foldable (toList)
 import Data.Map (Map)

--- a/src/Ersatz/Equatable.hs
+++ b/src/Ersatz/Equatable.hs
@@ -70,6 +70,10 @@ instance Equatable v => Equatable (Seq.Seq v) where
     | Seq.length x == Seq.length y = toList x === toList y
     | otherwise                    = false
 
+-- manually written because ancient GHC didn't have the generics instance
+instance Equatable a => Equatable (Tree.Tree a) where
+  Tree.Node x xs === Tree.Node y ys = x === y && xs === ys
+
 instance (Equatable a, Equatable b) => Equatable (a,b)
 instance (Equatable a, Equatable b, Equatable c) => Equatable (a,b,c)
 instance (Equatable a, Equatable b, Equatable c, Equatable d) => Equatable (a,b,c,d)
@@ -80,7 +84,6 @@ instance Equatable a => Equatable (Maybe a)
 instance Equatable a => Equatable [a]
 instance Equatable a => Equatable (NonEmpty a)
 instance (Equatable a, Equatable b) => Equatable (Either a b)
-instance Equatable a => Equatable (Tree.Tree a)
 
 class GEquatable f where
   (===#) :: f a -> f a -> Bit

--- a/src/Ersatz/Equatable.hs
+++ b/src/Ersatz/Equatable.hs
@@ -24,10 +24,18 @@ import Prelude hiding ((&&),(||),not,and,or,all,any)
 
 import Ersatz.Bit
 import GHC.Generics
+import GHC.Natural
 import Data.IntMap (IntMap)
+import Data.Foldable (toList)
 import Data.Map (Map)
+import Data.Int
+import Data.Word
+import Data.Void
+import Data.List.NonEmpty (NonEmpty)
 import qualified Data.Map as Map
 import qualified Data.IntMap as IntMap
+import qualified Data.Sequence as Seq
+import qualified Data.Tree as Tree
 
 infix  4 ===, /==
 
@@ -57,6 +65,11 @@ instance Equatable v => Equatable (IntMap v) where
     | IntMap.keys x == IntMap.keys y = IntMap.elems x === IntMap.elems y
     | otherwise                      = false
 
+instance Equatable v => Equatable (Seq.Seq v) where
+  x === y
+    | Seq.length x == Seq.length y = toList x === toList y
+    | otherwise                    = false
+
 instance (Equatable a, Equatable b) => Equatable (a,b)
 instance (Equatable a, Equatable b, Equatable c) => Equatable (a,b,c)
 instance (Equatable a, Equatable b, Equatable c, Equatable d) => Equatable (a,b,c,d)
@@ -65,7 +78,9 @@ instance (Equatable a, Equatable b, Equatable c, Equatable d, Equatable e, Equat
 instance (Equatable a, Equatable b, Equatable c, Equatable d, Equatable e, Equatable f, Equatable g) => Equatable (a,b,c,d,e,f,g)
 instance Equatable a => Equatable (Maybe a)
 instance Equatable a => Equatable [a]
+instance Equatable a => Equatable (NonEmpty a)
 instance (Equatable a, Equatable b) => Equatable (Either a b)
+instance Equatable a => Equatable (Tree.Tree a)
 
 class GEquatable f where
   (===#) :: f a -> f a -> Bit
@@ -89,3 +104,25 @@ instance GEquatable f => GEquatable (M1 i c f) where
 
 instance Equatable a => GEquatable (K1 i a) where
   K1 a ===# K1 b = a === b
+
+-- Boring instances that end up being useful when deriving Equatable with Generics
+
+instance Equatable ()       where _ === _ = true
+instance Equatable Void     where x === y = x `seq` y `seq` error "Equatable[Void].==="
+instance Equatable Int      where x === y = bool (x == y)
+instance Equatable Integer  where x === y = bool (x == y)
+instance Equatable Natural  where x === y = bool (x == y)
+instance Equatable Word     where x === y = bool (x == y)
+instance Equatable Word8    where x === y = bool (x == y)
+instance Equatable Word16   where x === y = bool (x == y)
+instance Equatable Word32   where x === y = bool (x == y)
+instance Equatable Word64   where x === y = bool (x == y)
+instance Equatable Int8     where x === y = bool (x == y)
+instance Equatable Int16    where x === y = bool (x == y)
+instance Equatable Int32    where x === y = bool (x == y)
+instance Equatable Int64    where x === y = bool (x == y)
+instance Equatable Char     where x === y = bool (x == y)
+instance Equatable Float    where x === y = bool (x == y)
+instance Equatable Double   where x === y = bool (x == y)
+instance Equatable Ordering where x === y = bool (x == y)
+instance Equatable Bool     where x === y = bool (x == y)


### PR DESCRIPTION
These instances make it easier to use GHC.Generics to derive Equatable on types with concrete values.