### PR TITLE
Import entities from Control.Monad explicitly since mtl-2.3 stops re-exporting Control.Monad

### DIFF
--- a/examples/regexp-grid/RegexpGrid/Problem.hs
+++ b/examples/regexp-grid/RegexpGrid/Problem.hs
@@ -10,6 +10,7 @@ import Prelude hiding ((&&), (||), not, and, or, all, any)
 
 import Control.Applicative
 import qualified Control.Monad.Fail as Fail
+import Control.Monad (guard)
 import Control.Monad.Reader
 import Control.Monad.RWS.Strict hiding ((<>))
 import Control.Lens

--- a/examples/sudoku/Sudoku/Problem.hs
+++ b/examples/sudoku/Sudoku/Problem.hs
@@ -3,6 +3,7 @@ module Sudoku.Problem (problem, range) where
 
 import Prelude hiding ((&&), (||), not, and, or, all, any)
 
+import Control.Monad (forM_, replicateM, when)
 import Control.Monad.Reader
 import Data.Array (Array, (!))
 import qualified Data.Array as Array


### PR DESCRIPTION
I noticed that `ersatz` failed to compile with `mtl-2.3` with the following errors:

```
ersatz/examples/regexp-grid/RegexpGrid/Problem.hs:134:19: error:
    Variable not in scope: guard :: Bool -> m b
    |
134 |     endOfFields = guard . Seq.null =<< use rbsFields
    |                   ^^^^^
```

```
ersatz/examples/sudoku/Sudoku/Problem.hs:27:17: error:
    • Variable not in scope: replicateM :: Int -> m2 a1 -> m [Cell]
    • Perhaps you meant ‘replicate’ (imported from Prelude)
   |
27 |             <$> replicateM (Array.rangeSize range) exists
   |                 ^^^^^^^^^^

ersatz/examples/sudoku/Sudoku/Problem.hs:32:3: error:
    Variable not in scope:
      forM_ :: [(Index, Word8)] -> ((Index, Word8) -> t1) -> m a0
   |
32 |   forM_ (Array.assocs initValues) $ \(idx, val) ->
   |   ^^^^^

ersatz/examples/sudoku/Sudoku/Problem.hs:33:5: error:
    Variable not in scope: when :: Bool -> m1 () -> t1
   |
33 |     when (1 <= val && val <= 9) $
   |     ^^^^

ersatz/examples/sudoku/Sudoku/Problem.hs:58:3: error:
    Variable not in scope:
      forM_ :: [(Cell, Cell)] -> ((t0, t0) -> m0 ()) -> ReaderT Env m ()
   |
58 |   forM_ pairs $ \(cellA, cellB) -> assert (cellA /== cellB)
   |   ^^^^^
```

This is because `mtl-2.3` [stopped re-exporing `Control.Monad` from `Control.Monad.Reader`](https://github.com/haskell/mtl/pull/74) so that importing `Control.Monad.Reader` is not enough for using those functions.

Note that `mtl-2.3` was [deprecated](https://github.com/haskell/mtl/issues/117#issuecomment-1132032909), so there may be no need to rush to fix the issue.