### PR TITLE
Avoid `-Wx-partial` warnings with GHC 9.8+

### DIFF
--- a/tests/Speed.hs
+++ b/tests/Speed.hs
@@ -16,8 +16,12 @@ mainf n = do
   putStrLn $ unwords [ "n",  show n ]
   (s, mgs) <- solveWith anyminisat $ do
       gs <- replicateM n exists
-      forM_ (zip gs $ tail gs) $ \ (x,y) -> assert ( x /== y )
+      forM_ (zipTail gs) $ \ (x,y) -> assert ( x /== y )
       return (gs :: [Bit])
   case (s, mgs) of
      (Satisfied, Just gs) -> do print $ length $ filter id gs
      _ -> do return ()
+
+zipTail :: [a] -> [(a, a)]
+zipTail []         = []
+zipTail xss@(_:xs) = zip xss xs


### PR DESCRIPTION
GHC 9.8 adds the `-Wx-partial` warning to `-Wall`, which is triggered upon any use of the partial `head` or `tail` functions from `Prelude`. This patch rewrites some code in `ersatz` to avoid `head`/`tail`, and thereby avoid new warnings with GHC 9.8. Sometimes, this can be achieved by some mild refactoring, but in other cases, we simply have to accept the partiality inherent in some code and make the error cases more explicit.