### PR TITLE
Monomorphise `decode`/`solveWith` to `Maybe` (#61) and fix #60/#76 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,19 @@
   2. The behavior of `decode` and `solveWith` for `MonadPlus` instances besides
      `Maybe` could  produce surprising results, as this behavior was not well
      specified.
+* Fix a bug in which `decode` could return inconsistent results with solution
+  that underconstrain variables. For instance:
+
+  ```hs
+  do b <- exists
+     pure [b, not b]
+  ```
+
+  Previously, this could decode to `[False, False]` (an invalid assignment).
+  `ersatz` now adopts the convention that unconstrained non-negative `Literal`s
+  will always be assigned `False`, and unconstrained negative `Literal`s will
+  always be assigned `True`. This means that the example above would now decode
+  to `[False, True]`.
 
 0.4.13 [2022.11.01]
 -------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,24 @@
 * The `forall` function in `Ersatz.Variable` has been renamed to
   `forall_`, since a future version of GHC will make the use of `forall` as an
   identifier an error.
+* The types of `decode` and `solveWith` have been slightly less general:
+
+  ```diff
+  -decode :: MonadPlus f => Solution -> a -> f     (Decoded a)
+  +decode ::                Solution -> a -> Maybe (Decoded a)
+
+  -solveWith :: (Monad m, MonadPlus n, HasSAT s, Default s, Codec a) => Solver s m -> StateT s m a -> m (Result, n     (Decoded a))
+  +solveWith :: (Monad m,              HasSAT s, Default s, Codec a) => Solver s m -> StateT s m a -> m (Result, Maybe (Decoded a))
+  ```
+
+  That is, these functions now use `Maybe` instead of an arbitrary `MonadPlus`.
+  This change came about because:
+
+  1. Practically all uses of `solveWith` in the wild are already picking `n` to
+     be `Maybe`, and
+  2. The behavior of `decode` and `solveWith` for `MonadPlus` instances besides
+     `Maybe` could  produce surprising results, as this behavior was not well
+     specified.
 
 0.4.13 [2022.11.01]
 -------------------

--- a/ersatz.cabal
+++ b/ersatz.cabal
@@ -273,6 +273,21 @@ executable ersatz-sudoku
 --   hs-source-dirs: tests
 --   Main-is: properties.hs
 
+test-suite hunit
+  type: exitcode-stdio-1.0
+  main-is: HUnit.hs
+  hs-source-dirs: tests
+  build-depends:
+    base,
+    containers,
+    data-default,
+    ersatz,
+    HUnit >= 1.2,
+    test-framework >= 0.6,
+    test-framework-hunit >= 0.2
+  default-language: Haskell2010
+  ghc-options: -Wall
+
 test-suite speed
   type: exitcode-stdio-1.0
   main-is: Speed.hs

--- a/src/Ersatz/Bit.hs
+++ b/src/Ersatz/Bit.hs
@@ -27,7 +27,7 @@ import Prelude hiding ((&&),(||),not,and,or,all,any)
 import qualified Prelude
 
 import Control.Applicative
-import Control.Monad (MonadPlus(..), liftM2, liftM3)
+import Control.Monad (liftM2, liftM3)
 import Data.Foldable (toList)
 import qualified Data.Foldable as Foldable
 import qualified Data.Traversable as Traversable
@@ -123,8 +123,7 @@ instance Codec Bit where
   type Decoded Bit = Bool
   encode = bool
   decode sol b
-      = maybe (pure False <|> pure True) pure $
-        solutionStableName sol (unsafePerformIO (makeStableName' b))
+      = solutionStableName sol (unsafePerformIO (makeStableName' b))
      -- The StableName didn’t have an associated literal with a solution,
      -- recurse to compute the value.
     <|> case b of
@@ -135,7 +134,9 @@ instance Codec Bit where
             decode sol $ if p then ct else cf
           Not c'  -> not <$> decode sol c'
           Var l   -> decode sol l
-          Run _ -> mzero
+          Run _ -> Nothing
+      -- If all else false, just return False.
+    <|> Just False
     where
       andMaybeBools :: [Maybe Bool] -> Maybe Bool
       andMaybeBools mbs

--- a/src/Ersatz/Codec.hs
+++ b/src/Ersatz/Codec.hs
@@ -35,9 +35,18 @@ class Codec a where
   decode :: Solution -> a -> Maybe (Decoded a)
   encode :: Decoded a -> a
 
+-- | By convention, the 'decode' implementation will return 'False' for
+-- unconstrained non-negative 'Literal's and 'True' for unconstrained negative
+-- 'Literal's.
 instance Codec Literal where
   type Decoded Literal = Bool
-  decode s a = solutionLiteral s a <|> Just False
+  decode s a = case solutionLiteral s a of
+                 sol@(Just _) -> sol
+                 Nothing
+                   | i >= 0    -> Just False
+                   | otherwise -> Just True
+    where
+      i = literalId a
   encode True  = literalTrue
   encode False = literalFalse
 

--- a/src/Ersatz/Codec.hs
+++ b/src/Ersatz/Codec.hs
@@ -30,13 +30,14 @@ import Prelude hiding (mapM)
 -- | This class describes data types that can be marshaled to or from a SAT solver.
 class Codec a where
   type Decoded a :: Type
-  -- | Return a value based on the solution if one can be determined.
-  decode :: MonadPlus f => Solution -> a -> f (Decoded a)
+  -- | Return 'Just' a value based on the solution if one can be determined.
+  -- Otherwise, return 'Nothing'.
+  decode :: Solution -> a -> Maybe (Decoded a)
   encode :: Decoded a -> a
 
 instance Codec Literal where
   type Decoded Literal = Bool
-  decode s a = maybe (pure False <|> pure True) pure (solutionLiteral s a)
+  decode s a = solutionLiteral s a <|> Just False
   encode True  = literalTrue
   encode False = literalFalse
 

--- a/src/Ersatz/Solution.hs
+++ b/src/Ersatz/Solution.hs
@@ -24,6 +24,9 @@ import System.Mem.StableName (StableName)
 
 data Solution = Solution
   { solutionLiteral    :: Literal -> Maybe Bool
+    -- ^ If a 'Literal' is uniquely assigned to a particular value, this will
+    -- return 'Just' of that value. If a 'Literal' is unconstrained (i.e., it
+    -- can be assigned either 'True' or 'False'), this will return 'Nothing'.
   , solutionStableName :: StableName () -> Maybe Bool
   }
 

--- a/src/Ersatz/Solver.hs
+++ b/src/Ersatz/Solver.hs
@@ -14,7 +14,6 @@ module Ersatz.Solver
   , solveWith
   ) where
 
-import Control.Monad
 import Control.Monad.State
 import Data.Default
 import Ersatz.Codec
@@ -25,8 +24,8 @@ import Ersatz.Solver.Minisat
 import Ersatz.Solver.Z3
 
 solveWith ::
-  (Monad m, MonadPlus n, HasSAT s, Default s, Codec a) =>
-  Solver s m -> StateT s m a -> m (Result, n (Decoded a))
+  (Monad m, HasSAT s, Default s, Codec a) =>
+  Solver s m -> StateT s m a -> m (Result, Maybe (Decoded a))
 solveWith solver m = do
   (a, problem) <- runStateT m def
   (res, litMap) <- solver problem

--- a/src/Ersatz/Solver.hs
+++ b/src/Ersatz/Solver.hs
@@ -23,6 +23,36 @@ import Ersatz.Solver.DepQBF
 import Ersatz.Solver.Minisat
 import Ersatz.Solver.Z3
 
+-- | @'solveWith' solver prob@ solves a SAT problem @prob@ with the given
+-- @solver@. It returns a pair consisting of:
+--
+-- 1. A 'Result' that indicates if @prob@ is satisfiable ('Satisfied'),
+--    unsatisfiable ('Unsatisfied'), or if the solver could not determine any
+--    results ('Unsolved').
+--
+-- 2. A 'Decoded' answer that was decoded using the solution to @prob@. Note
+--    that this answer is only meaningful if the 'Result' is 'Satisfied' and
+--    the answer value is in a 'Just'.
+--
+-- Here is a small example of how to use 'solveWith':
+--
+-- @
+-- import Ersatz
+--
+-- main :: IO ()
+-- main = do
+--   res <- 'solveWith' minisat $ do
+--     (b1 :: Bit) <- exists
+--     (b2 :: Bit) <- exists
+--     assert (b1 === b2)
+--     pure [b1, b2]
+--   case res of
+--     (Satisfied, Just answer) -> print answer
+--     _ -> fail "Could not solve problem"
+-- @
+--
+-- Depending on the whims of @minisat@, this program may print either
+-- @[False, False]@ or @[True, True]@.
 solveWith ::
   (Monad m, HasSAT s, Default s, Codec a) =>
   Solver s m -> StateT s m a -> m (Result, Maybe (Decoded a))

--- a/tests/HUnit.hs
+++ b/tests/HUnit.hs
@@ -1,0 +1,38 @@
+-- | @HUnit@-based unit tests for @ersatz@.
+module Main where
+
+import Prelude hiding ((||), (&&), not)
+
+import Data.Default
+import qualified Data.IntMap.Strict as IntMap
+
+import Test.Framework
+import Test.Framework.Providers.HUnit
+import Test.HUnit (Assertion, (@?=))
+
+import Ersatz
+import Ersatz.Internal.Literal
+
+main :: IO ()
+main = defaultMain tests
+
+tests :: [Test]
+tests =
+  [ testGroup "unit tests"
+      [ testCase "unconstrained literals" case_unconstrained_literals
+      ]
+  ]
+
+-- A regression test for #60 and #76.
+case_unconstrained_literals :: Assertion
+case_unconstrained_literals =
+    decode sol [b1, not b1, b2, not b2, b1 || b2, b1 && b2] @?=
+      Just [False, True, False, True, False, False]
+      -- There are other valid answers, but in practice, ersatz will choose this
+      -- one due to the convention that the Codec Literal instance always
+      -- assigns non-negative unconstrained Literals to False and negative
+      -- unconstrained Literals to True.
+  where
+    sol = solutionFrom (IntMap.fromList [(1, True)]) (def :: SAT)
+    b1 = Var $ Literal 2
+    b2 = Var $ Literal 3


### PR DESCRIPTION
This PR is a collection of patches that, when taken together, fix #60, #61, and #76:

## Use `Maybe` (instead of an arbitrary `MonadPlus`) in `decode` and `solveWith`

As noted in https://github.com/ekmett/ersatz/issues/61, it's not clear what the intended behavior of `decode`/`solveWith` should be for `MonadPlus` instances like `[]`. Moreover, the internals of `ersatz` more-or-less already assume that we are working in `Maybe`, and nearly all uses of `solveWith` in the wild pick `Maybe` to begin with. To avoid potential confusion, let's just concretize `decode`/`solveWith` to always work over `Maybe`.

Fixes https://github.com/ekmett/ersatz/issues/61.

## Return consistent results for unconstrained literals

Previously, `ersatz` would always decode every unconstrained `Literal` to `False`, which could produce inconsistent results for things like `do { b <- exists; pure [b, not b] }`, which would decode to `[False, False]`. We now adopt the convention that unconstrained non-negative `Literal`s always decode to `False`, and that unconstrained negative `Literal`s always decode to `True`, so the example above now decodes to `[False, True]`.

Fixes https://github.com/ekmett/ersatz/issues/60. Fixes https://github.com/ekmett/ersatz/issues/76.

## Provide Haddocks for `solveWith`

The exact meaning of what `solveWith` returns is not obvious at a first glance. This patch provides some Haddocks for `solveWith` that better explains this and provides a complete example of how to use `solveWith`.