### PR TITLE
Add functions for writing *SAT problems to a dimacs file

### DIFF
--- a/src/Ersatz/Solver/DepQBF.hs
+++ b/src/Ersatz/Solver/DepQBF.hs
@@ -16,7 +16,7 @@ module Ersatz.Solver.DepQBF
 
 import Data.ByteString.Builder
 import Control.Monad.IO.Class
-import Ersatz.Problem
+import Ersatz.Problem ( QSAT, writeQdimacs' )
 import Ersatz.Solution
 import Ersatz.Solver.Common
 import qualified Data.IntMap as I
@@ -50,8 +50,7 @@ parseOutput out =
 depqbfPath :: MonadIO m => FilePath -> Solver QSAT m
 depqbfPath path problem = liftIO $
   withTempFiles ".cnf" "" $ \problemPath _ -> do
-    withFile problemPath WriteMode $ \fh ->
-      hPutBuilder fh (qdimacs problem)
+    writeQdimacs' problemPath problem
 
     (exit, out, _err) <-
       readProcessWithExitCode path [problemPath, "--qdo"] []

--- a/src/Ersatz/Solver/Minisat.hs
+++ b/src/Ersatz/Solver/Minisat.hs
@@ -23,7 +23,7 @@ import Data.ByteString.Builder
 import Control.Exception (IOException, handle)
 import Control.Monad.IO.Class
 import Data.IntMap (IntMap)
-import Ersatz.Problem
+import Ersatz.Problem ( SAT, writeDimacs' )
 import Ersatz.Solution
 import Ersatz.Solver.Common
 import qualified Data.IntMap.Strict as IntMap
@@ -51,8 +51,7 @@ cryptominisat = minisatPath "cryptominisat"
 minisatPath :: MonadIO m => FilePath -> Solver SAT m
 minisatPath path problem = liftIO $
   withTempFiles ".cnf" "" $ \problemPath solutionPath -> do
-    withFile problemPath WriteMode $ \fh ->
-      hPutBuilder fh (dimacs problem)
+    writeDimacs' problemPath problem
 
     (exit, _out, _err) <-
       readProcessWithExitCode path [problemPath, solutionPath] []
@@ -87,8 +86,7 @@ cryptominisat5 = cryptominisat5Path "cryptominisat5"
 cryptominisat5Path :: MonadIO m => FilePath -> Solver SAT m
 cryptominisat5Path path problem = liftIO $
   withTempFiles ".cnf" "" $ \problemPath _ -> do
-    withFile problemPath WriteMode $ \fh ->
-      hPutBuilder fh (dimacs problem)
+    writeDimacs' problemPath problem
 
     (exit, out, _err) <-
       readProcessWithExitCode path [problemPath] []

--- a/src/Ersatz/Solver/Z3.hs
+++ b/src/Ersatz/Solver/Z3.hs
@@ -14,7 +14,7 @@ module Ersatz.Solver.Z3
 
 import Data.ByteString.Builder
 import Control.Monad.IO.Class
-import Ersatz.Problem
+import Ersatz.Problem ( SAT, writeDimacs' )
 import Ersatz.Solution
 import Ersatz.Solver.Common
 import System.IO
@@ -30,8 +30,7 @@ z3 = z3Path "z3"
 z3Path :: MonadIO m => FilePath -> Solver SAT m
 z3Path path problem = liftIO $
   withTempFiles ".cnf" "" $ \problemPath _ -> do
-    withFile problemPath WriteMode $ \fh ->
-      hPutBuilder fh (dimacs problem)
+    writeDimacs' problemPath problem
 
     (_exit, out, _err) <-
       readProcessWithExitCode path ["-dimacs", problemPath] []


### PR DESCRIPTION
This PR adds functions to facilitate writing a problem to a *dimacs file. The intended use cases include experimentation with command-line options to solvers with existing `ersatz` support +/- experimentation with solvers that don't have explicit `ersatz` support.