### PR TITLE
Add support for the Kissat solver and the lingeling trio of solvers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ next [????.??.??]
   -buildFrom :: (Ix a, Ix b) => (a -> b -> Bit) -> ((a,b),(a,b))  -> Relation a b
   +buildFrom :: (Ix a, Ix b) => ((a,b),(a,b))   -> ((a,b) -> Bit) -> Relation a b
   ```
+* Add support for `kissat` and the `lingeling` trio (`lingeling`, `plingeling`,
+  `treengeling`) of SAT solvers.
 
 0.5 [2023.09.08]
 ----------------

--- a/ersatz.cabal
+++ b/ersatz.cabal
@@ -197,6 +197,8 @@ library
     Ersatz.Solution
     Ersatz.Solver
     Ersatz.Solver.DepQBF
+    Ersatz.Solver.Kissat
+    Ersatz.Solver.Lingeling
     Ersatz.Solver.Minisat
     Ersatz.Solver.Z3
     Ersatz.Variable

--- a/src/Ersatz/Solver.hs
+++ b/src/Ersatz/Solver.hs
@@ -9,6 +9,8 @@
 --------------------------------------------------------------------
 module Ersatz.Solver
   ( module Ersatz.Solver.DepQBF
+  , module Ersatz.Solver.Kissat
+  , module Ersatz.Solver.Lingeling
   , module Ersatz.Solver.Minisat
   , module Ersatz.Solver.Z3
   , solveWith
@@ -20,6 +22,8 @@ import Ersatz.Codec
 import Ersatz.Problem
 import Ersatz.Solution
 import Ersatz.Solver.DepQBF
+import Ersatz.Solver.Kissat
+import Ersatz.Solver.Lingeling
 import Ersatz.Solver.Minisat
 import Ersatz.Solver.Z3
 

--- a/src/Ersatz/Solver/Kissat.hs
+++ b/src/Ersatz/Solver/Kissat.hs
@@ -1,0 +1,50 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Ersatz.Solver.Kissat
+  ( kissat
+  , kissatPath
+  ) where
+
+import Control.Monad.IO.Class
+  ( MonadIO ( liftIO
+            )
+  )
+import Ersatz.Problem
+  ( SAT
+  , writeDimacs'
+  )
+import Ersatz.Solution
+  ( Solver
+  )
+import Ersatz.Solver.Common
+  ( resultOf
+  , withTempFiles
+  , parseSolution5
+  )
+import System.Process
+  ( readProcessWithExitCode
+  )
+
+
+-- | 'Solver' for 'SAT' problems that tries to invoke the @kissat@ executable
+-- from the @PATH@.
+kissat :: MonadIO m => Solver SAT m
+kissat = kissatPath "kissat"
+
+-- | 'Solver' for 'SAT' problems that tries to invoke a program that takes
+-- @kissat@ compatible arguments.
+--
+-- The 'FilePath' refers to the path to the executable.
+kissatPath :: MonadIO m => FilePath -> Solver SAT m
+kissatPath path problem = liftIO $
+  withTempFiles ".cnf" "" $ \problemPath _ -> do
+    writeDimacs' problemPath problem
+
+    (exit, out, _err) <-
+      readProcessWithExitCode path
+                              [problemPath]
+                              []
+
+    let sol = parseSolution5 out
+
+    return (resultOf exit, sol)

--- a/src/Ersatz/Solver/Lingeling.hs
+++ b/src/Ersatz/Solver/Lingeling.hs
@@ -1,0 +1,84 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Ersatz.Solver.Lingeling
+  ( lingeling
+  , plingeling
+  , treengeling
+  , lingelingPath
+  , plingelingPath
+  , treengelingPath
+  ) where
+
+import Control.Monad.IO.Class
+  ( MonadIO ( liftIO
+            )
+  )
+import Ersatz.Problem
+  ( SAT
+  , writeDimacs'
+  )
+import Ersatz.Solution
+  ( Solver
+  )
+import Ersatz.Solver.Common
+  ( resultOf
+  , withTempFiles
+  , parseSolution5
+  )
+import System.Process
+  ( readProcessWithExitCode
+  )
+
+-- | 'Solver' for 'SAT' problems that tries to invoke the @lingeling@ executable
+-- from the @PATH@.
+lingeling :: MonadIO m => Solver SAT m
+lingeling = lingelingPath "lingeling"
+
+-- | 'Solver' for 'SAT' problems that tries to invoke the @plingeling@ executable
+-- from the @PATH@.
+plingeling :: MonadIO m => Solver SAT m
+plingeling = ngelingPath "plingeling"
+
+-- | 'Solver' for 'SAT' problems that tries to invoke the @treengeling@ executable
+-- from the @PATH@.
+treengeling :: MonadIO m => Solver SAT m
+treengeling = ngelingPath "treengeling"
+
+-- | 'Solver' for 'SAT' problems that tries to invoke a program that takes
+-- @lingeling@ compatible arguments.
+--
+-- The 'FilePath' refers to the path to the executable.
+lingelingPath :: MonadIO m => FilePath -> Solver SAT m
+lingelingPath = ngelingPath
+
+-- | 'Solver' for 'SAT' problems that tries to invoke a program that takes
+-- @plingeling@ compatible arguments.
+--
+-- The 'FilePath' refers to the path to the executable.
+plingelingPath :: MonadIO m => FilePath -> Solver SAT m
+plingelingPath = ngelingPath
+
+-- | 'Solver' for 'SAT' problems that tries to invoke a program that takes
+-- @treengeling@ compatible arguments.
+--
+-- The 'FilePath' refers to the path to the executable.
+treengelingPath :: MonadIO m => FilePath -> Solver SAT m
+treengelingPath = ngelingPath
+
+-- | 'Solver' for 'SAT' problems that tries to invoke a program that takes
+-- @*ngeling@ compatible arguments.
+--
+-- The 'FilePath' refers to the path to the executable.
+ngelingPath :: MonadIO m => FilePath -> Solver SAT m
+ngelingPath path problem = liftIO $
+  withTempFiles ".cnf" "" $ \problemPath _ -> do
+    writeDimacs' problemPath problem
+
+    (exit, out, _err) <-
+      readProcessWithExitCode path
+                              [problemPath]
+                              []
+
+    let sol = parseSolution5 out
+
+    return (resultOf exit, sol)


### PR DESCRIPTION
Per the title, this adds support for `kissat`, `lingeling`, `plingeling`, and `treengeling` to `Ersatz`.